### PR TITLE
Message User Relationship

### DIFF
--- a/config/laravel_ticket.php
+++ b/config/laravel_ticket.php
@@ -39,6 +39,7 @@ return [
              * @see https://laravel.com/docs/9.x/eloquent-relationships#one-to-many
              */
             'columns' => [
+                'user_foreing_id' => 'user_id',
                 'ticket_foreing_id' => 'ticket_id',
             ],
         ],

--- a/database/migrations/create_messages_table.php.stub
+++ b/database/migrations/create_messages_table.php.stub
@@ -15,7 +15,7 @@ return new class extends Migration
 
         Schema::create($tableName['table'], function (Blueprint $table) use ($tableName) {
             $table->id();
-            $table->foreignId('user_id');
+            $table->foreignId($tableName['columns']['user_foreing_id']);
             $table->foreignId($tableName['columns']['ticket_foreing_id']);
             $table->text('message');
             $table->timestamps();

--- a/src/Models/Message.php
+++ b/src/Models/Message.php
@@ -39,6 +39,21 @@ class Message extends Model
     }
 
     /**
+     * Get Message Relationship
+     * 
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     */
+    public function user(): BelongsTo
+    {
+        $tableName = config('laravel_ticket.table_names.messages', 'message');
+
+        return $this->belongsTo(
+            config('auth.providers.users.model'),
+            $tableName['columns']['user_foreing_id']
+        );
+    }
+
+    /**
      * Get the table associated with the model.
      *
      * @return string

--- a/src/Models/Message.php
+++ b/src/Models/Message.php
@@ -40,7 +40,7 @@ class Message extends Model
 
     /**
      * Get Message Relationship
-     * 
+     *
      * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
      */
     public function user(): BelongsTo

--- a/tests/Feature/MessageTest.php
+++ b/tests/Feature/MessageTest.php
@@ -19,7 +19,7 @@ it('message can be associated to a user', function () {
     $user = User::factory()->create([
         'name' => 'Oussama',
     ]);
-    
+
     $message = Message::factory()->create();
 
     $message->user()->associate($user);

--- a/tests/Feature/MessageTest.php
+++ b/tests/Feature/MessageTest.php
@@ -2,6 +2,7 @@
 
 use Coderflex\LaravelTicket\Models\Message;
 use Coderflex\LaravelTicket\Models\Ticket;
+use Coderflex\LaravelTicket\Tests\Models\User;
 
 it('can attach message to a ticket', function () {
     $message = Message::factory()->create();
@@ -12,4 +13,16 @@ it('can attach message to a ticket', function () {
     $message->ticket()->associate($ticket);
 
     $this->assertEquals($message->ticket->title, 'Can you create a message?');
+});
+
+it('message can be associated to a user', function () {
+    $user = User::factory()->create([
+        'name' => 'Oussama',
+    ]);
+    
+    $message = Message::factory()->create();
+
+    $message->user()->associate($user);
+
+    $this->assertEquals($message->user->name, 'Oussama');
 });


### PR DESCRIPTION
Adding `user` relationship, into the `Message` model, so you can get the user data directly from the message

Example
```php
$message = Message::first();

return $message->user->name // you can get the user data.
```