### PR TITLE
Laravel v11 compitable

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,19 +18,19 @@
     "require": {
         "php": "^8.1",
         "spatie/laravel-package-tools": "^1.13.0",
-        "illuminate/contracts": "^9.0|^10.0"
+        "illuminate/contracts": "^9.0|^10.0|^11.0"
     },
     "require-dev": {
         "laravel/pint": "^1.0",
-        "nunomaduro/collision": "^6.0|^7.0",
+        "nunomaduro/collision": "^6.0|^7.0|^8.0",
         "nunomaduro/larastan": "^2.0.1",
-        "orchestra/testbench": "^7.0|^8.0",
+        "orchestra/testbench": "^7.0|^8.0|^9.0",
         "pestphp/pest": "^1.21",
         "pestphp/pest-plugin-laravel": "^1.1",
         "phpstan/extension-installer": "^1.1",
         "phpstan/phpstan-deprecation-rules": "^1.0",
         "phpstan/phpstan-phpunit": "^1.0",
-        "phpunit/phpunit": "^9.5|^10.0"
+        "phpunit/phpunit": "^9.5|^10.0|^11.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This pull request updates the dependencies of this package to ensure compatibility with Laravel v11.

**Changes:**

Updated  `illuminate/contracts` to  `^11.0`
Updated  `nunomaduro/collision` to  `^8.0`
Updated  `orchestra/testbench` to  `^9.0`
Updated  `phpunit/phpunit` to  `^11.0`


**Benefits:**

This update allows users to leverage the latest features and security improvements of Laravel v11.
Improved compatibility across different Laravel versions.

**Next Steps:**

Please review the changes and provide any feedback.
If any breaking changes are identified, we can discuss potential solutions.