### PR TITLE
[Bugfix] Get table name from config - ticket table

### DIFF
--- a/src/Models/Ticket.php
+++ b/src/Models/Ticket.php
@@ -104,7 +104,7 @@ class Ticket extends Model
     public function getTable()
     {
         return config(
-            'laravel_ticket.models.tickets',
+            'laravel_ticket.table_names.tickets',
             parent::getTable()
         );
     }


### PR DESCRIPTION
Just figure out this issue, loading wrong ticket table from configuration variable