### PR TITLE
Expand Laravel version support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "^8.1",
         "spatie/laravel-package-tools": "^1.13.0",
-        "illuminate/contracts": "^9.0|^10.0"
+        "illuminate/contracts": "^9.0|^10.0|^11.0|^12.0|^13.0"
     },
     "require-dev": {
         "laravel/pint": "^1.0",


### PR DESCRIPTION
Updates version constraints for Illuminate contracts to support Laravel 11, 12, and 13, ensuring compatibility with framework releases.